### PR TITLE
Babel 7 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,9 @@ module.exports = function (babel) {
 
         // now traverse and replace all instances within the scope
         var func = path.getFunctionParent();
+        if (!func) {
+          func = path.findParent(p => p.isProgram());
+        }
         func.traverse(fsApiVisitor(vars, state));
 
         // finally, remove the 'fs' import statements
@@ -76,6 +79,9 @@ module.exports = function (babel) {
 
           // now traverse and replace all instances within the scope
           var func = path.getFunctionParent();
+          if (!func) {
+            func = path.findParent(p => p.isProgram());
+          }
           func.traverse(fsApiVisitor(vars, state));
 
           // finally, remove the 'fs' require statements


### PR DESCRIPTION
The plugin was relying on `getFunctionParent` to return the Program, but this no longer happens in babel 7.

For backwards compatibility, this gets the program only if `getFunctionParent` doesn't return anything.