### PR TITLE
fix: support `import * as fs from "fs"`

### DIFF
--- a/lib/get-module-function.js
+++ b/lib/get-module-function.js
@@ -56,6 +56,9 @@ function getImportRequireDetails (path, binding, localVar) {
       var imported = binding.path.node.imported;
       funcName = imported.name;
       return [ moduleName, funcName ];
+    } else if (t.isImportNamespaceSpecifier(binding.path)){
+      // e.g. import * as path from 'path'
+      return [ moduleName ];
     }
   } else {
     // The module is required with CommonJS

--- a/test/fixtures/es6-5.actual.js
+++ b/test/fixtures/es6-5.actual.js
@@ -1,0 +1,3 @@
+import * as fs from 'fs';
+const str = fs.readFileSync(__dirname + '/hello.txt', 'utf8');
+console.log(str);

--- a/test/fixtures/path3.actual.js
+++ b/test/fixtures/path3.actual.js
@@ -1,0 +1,4 @@
+import * as path from 'path';
+import * as fs from "fs";
+const str = fs.readFileSync(path.join(__dirname + '/hello.txt'), 'utf8');
+console.log(str);

--- a/test/fixtures/path3.expected.js
+++ b/test/fixtures/path3.expected.js
@@ -1,0 +1,4 @@
+import * as path from 'path';
+
+const str = 'hello';
+console.log(str);

--- a/test/index.js
+++ b/test/index.js
@@ -13,9 +13,11 @@ test('babel plugin to accept browserify transforms', function (t) {
   run('es6-2', 'common', 'es6 destructured import');
   run('es6-3', 'common', 'es6 import with "as" statement');
   run('es6-4', 'common', 'es6 import with "as" statement and other declarations');
+  run('es6-5', 'common', 'es6 import * as');
 
   run('path1', 'path1', 'path.join with CommonJS');
   run('path2', 'path2', 'path.join with es6');
+  run('path3', 'path3', 'import * as path with es6');
   run('multi', 'multi', 'path.join with multi var');
 
   run('readdir', 'readdir', 'readdirSync');


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [x] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

Currently, `babel-plugin-static-fs` can not transpile following code.

```js
import * as path from 'path';
import * as fs from "fs";
const str = fs.readFileSync(path.join(__dirname + '/hello.txt'), 'utf8');
console.log(str);
```

**Expected**:

```js
import * as path from 'path';

const str = 'hello';
console.log(str);
```

**Actual**

```
      else throw err
           ^

TypeError: Cannot read property '0' of undefined
```

## Solution Description

Support ImportNamespaceSpecifier.

- https://astexplorer.net/#/gist/ecedb10f09a27a29eb97930a74e515d0/c81dcf9baa19a60338d2b1a3f5b578954f3d189e

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [x] N/A

**Aditional comments:**
