### PR TITLE
fix: revert to original nodes if `evaluate` is failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,12 +126,10 @@ module.exports = function (babel) {
 
           // e.g. readFileSync(...) -> 'foobar'
           // e.g. fs.readFileSync(...) -> 'foobar'
-          // try {
-            evaluate(state.opts, path, state.file.opts.filename);
-          // } catch (err) {
-          //   console.error(err);
-          //   errors.push(err);
-          // }
+          const result = evaluate(state.opts, path, state.file.opts.filename);
+          if (result instanceof Error) {
+            errors.push(result);
+          }
         }
       }
     };

--- a/lib/static-eval.js
+++ b/lib/static-eval.js
@@ -23,10 +23,11 @@ module.exports = evaluate;
 function evaluate (opts, path, vars, modules, needsEval) {
   opts = opts || {}
 
-  // save replaced nodes for reverting nodes
-  const replacedMap = new Map();
+  // save replaced path and nodes for store nodes
+  const replacedList = [];
   const replaceWith = (path, node) => {
-    replacedMap.set(path, {
+    replacedList.push({
+      path: path,
       oldNode: path.node,
       newNode: node,
     });
@@ -120,10 +121,10 @@ function evaluate (opts, path, vars, modules, needsEval) {
       return result.value;
     }
   } catch (error) {
-    // revert to original nodes if evaluating error is happened
-    for (const [path, nodes] of replacedMap.entries()) {
-      path.replaceWith(nodes.oldNode);
-    }
+    // restore to original nodes if evaluating error is happened
+    replacedList.reverse().forEach(({path, oldNode}) => {
+      path.replaceWith(oldNode);
+    });
     return error;
   }
 }

--- a/lib/static-eval.js
+++ b/lib/static-eval.js
@@ -23,90 +23,107 @@ module.exports = evaluate;
 function evaluate (opts, path, vars, modules, needsEval) {
   opts = opts || {}
 
-  // Replace identifiers with known values
-  path.traverse({
-    Identifier: function (ident) {
-      var key = ident.node.name;
-      if (key in vars) {
-        ident.replaceWith(t.valueToNode(vars[key]));
+  // save replaced nodes for reverting nodes
+  const replacedMap = new Map();
+  const replaceWith = (path, node) => {
+    replacedMap.set(path, {
+      oldNode: path.node,
+      newNode: node,
+    });
+    path.replaceWith(node);
+  };
+  try {
+    // Replace identifiers with known values
+    path.traverse({
+      Identifier: function (ident) {
+        var key = ident.node.name;
+        if (key in vars) {
+          replaceWith(ident, t.valueToNode(vars[key]));
+        }
       }
-    }
-  });
-
-  // `require.resolve(identifier)` is a CallExpression but cannot be evaluated with existing `evaluate()`
-  if (isRequireResolve(path)) {
-    // First evaluate all our arguments recursively
-    var argValues = path.get('arguments').map(function (arg) {
-      return evaluate(opts, arg, vars, modules, true);
     });
 
-    var id = argValues[0];
-    var resolveOpts = argValues[1] || {};
-    var target = opts.target || 'node';
+    // `require.resolve(identifier)` is a CallExpression but cannot be evaluated with existing `evaluate()`
+    if (isRequireResolve(path)) {
+      // First evaluate all our arguments recursively
+      var argValues = path.get('arguments').map(function (arg) {
+        return evaluate(opts, arg, vars, modules, true);
+      });
 
-    var str = resolveSync(target, id, {
-      basedir: vars.__dirname,
-      paths: resolveOpts.paths
-    });
+      var id = argValues[0];
+      var resolveOpts = argValues[1] || {};
+      var target = opts.target || 'node';
 
-    var computedNode = t.valueToNode(str);
-    path.replaceWith(computedNode);
-  }
-  // Evaluate recursively if it's a function call
-  else if (t.isCallExpression(path.node)) {
-    // First evaluate all our arguments recursively
-    var argValues = path.get('arguments').map(function (arg) {
-      return evaluate(opts, arg, vars, modules, true);
-    });
+      var str = resolveSync(target, id, {
+        basedir: vars.__dirname,
+        paths: resolveOpts.paths
+      });
 
-    // Now determine which static module & method name to call
-    var details = moduleDetails(path);
-    var moduleName = details[0];
-    var moduleFunc = details[1];
-
-    // Some safeguards
-    if (!(moduleName in modules)) {
-      throw new Error('Cannot evaluate ' + moduleName + '->' + moduleFunc + ', no known static module.');
+      var computedNode = t.valueToNode(str);
+      replaceWith(path, computedNode);
     }
-    var staticModule = modules[moduleName];
-    if (!(moduleFunc in staticModule)) {
-      throw new Error('The module "' + moduleName + '" does not seem to export ' + moduleFunc);
+    // Evaluate recursively if it's a function call
+    else if (t.isCallExpression(path.node)) {
+      // First evaluate all our arguments recursively
+      var argValues = path.get('arguments').map(function (arg) {
+        return evaluate(opts, arg, vars, modules, true);
+      });
+
+      // Now determine which static module & method name to call
+      var details = moduleDetails(path);
+      var moduleName = details[0];
+      var moduleFunc = details[1];
+
+      // Some safeguards
+      if (!(moduleName in modules)) {
+        throw new Error('Cannot evaluate ' + moduleName + '->' + moduleFunc + ', no known static module.');
+      }
+      var staticModule = modules[moduleName];
+      if (!(moduleFunc in staticModule)) {
+        throw new Error('The module "' + moduleName + '" does not seem to export ' + moduleFunc);
+      }
+
+      // Call our method and replace current path
+      var computedNode = staticModule[moduleFunc].apply(staticModule, argValues);
+      replaceWith(path, computedNode);
+    } else if (t.isObjectExpression(path.node)) {
+      var props = path.get('properties');
+      var resultingObj = {};
+      props.forEach(function (prop) {
+        var node = prop.node;
+        if (node.computed) {
+          throw new Error('Cannot handle computed property keys in arguments for static-fs');
+        }
+        if (!t.isIdentifier(node.key)) {
+          throw new Error('Can only handle simple { encoding: "hex" } type options in static-fs arguments');
+        }
+        var key = node.key.name;
+        var val = prop.get('value').evaluate();
+        if (!val.confident) {
+          throw new Error('Could not evaluate "' + key + '" in the object expression for static-fs');
+        }
+        resultingObj[key] = val.value;
+      });
+
+      // We evaluated a *simple* object expression like { encoding: 'hex' }
+      return resultingObj;
     }
 
-    // Call our method and replace current path
-    var computedNode = staticModule[moduleFunc].apply(staticModule, argValues);
-    path.replaceWith(computedNode);
-  } else if (t.isObjectExpression(path.node)) {
-    var props = path.get('properties');
-    var resultingObj = {};
-    props.forEach(function (prop) {
-      var node = prop.node;
-      if (node.computed) {
-        throw new Error('Cannot handle computed property keys in arguments for static-fs');
+    // Evaluate the new AST
+    if (needsEval) {
+      var result = path.evaluate();
+      if (!result.confident) {
+        throw new Error('Not able to statically evaluate the expression(s) for babel-plugin-static-fs.\n' +
+            'Try changing your source code to something that can be evaluated at build-time, e.g.\n' +
+            "    const src = fs.readFileSync(__dirname + '/foo.txt', 'utf8');\n");
       }
-      if (!t.isIdentifier(node.key)) {
-        throw new Error('Can only handle simple { encoding: "hex" } type options in static-fs arguments');
-      }
-      var key = node.key.name;
-      var val = prop.get('value').evaluate();
-      if (!val.confident) {
-        throw new Error('Could not evaluate "' + key + '" in the object expression for static-fs');
-      }
-      resultingObj[key] = val.value;
-    });
-
-    // We evaluated a *simple* object expression like { encoding: 'hex' }
-    return resultingObj;
-  }
-
-  // Evaluate the new AST
-  if (needsEval) {
-    var result = path.evaluate();
-    if (!result.confident) {
-      throw new Error('Not able to statically evaluate the expression(s) for babel-plugin-static-fs.\n' +
-          'Try changing your source code to something that can be evaluated at build-time, e.g.\n' +
-          "    const src = fs.readFileSync(__dirname + '/foo.txt', 'utf8');\n");
+      return result.value;
     }
-    return result.value;
+  } catch (error) {
+    // revert to original nodes if evaluating error is happened
+    for (const [path, nodes] of replacedMap.entries()) {
+      path.replaceWith(nodes.oldNode);
+    }
+    return error;
   }
 }

--- a/test/fixtures/dynamic.actual.js
+++ b/test/fixtures/dynamic.actual.js
@@ -9,3 +9,5 @@ function evaluated (blah) {
 }
 
 setTimeout(() => evaluated('/hello.txt'), 1500);
+const str2 = fs.readFileSync(path.join(__dirname, '/hello.txt'), 'utf8');
+console.log(str2);

--- a/test/fixtures/dynamic.expected.js
+++ b/test/fixtures/dynamic.expected.js
@@ -10,4 +10,6 @@ function evaluated(blah) {
   console.log(result);
 }
 
-setTimeout(evaluated, 1500);
+setTimeout(() => evaluated('/hello.txt'), 1500);
+const str2 = "hello";
+console.log(str2);

--- a/test/index.js
+++ b/test/index.js
@@ -31,7 +31,7 @@ test('babel plugin to accept browserify transforms', function (t) {
   });
   run('require-resolve', 'require-resolve', 'require.resolve with file');
 
-  // run('dynamic', 'dynamic', 'gracefully skips dynamic calls');
+  run('dynamic', 'dynamic', 'gracefully skips dynamic calls');
 
   // Failing test:
   // run('inline', 'inline', 'handles inline fs require call');


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No (Probably)

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [x] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

fix #15 

## Solution Description

1. Pre-save original `path` and `node` before inlining
2. When `evaluate()` throw error, revert to original `node`

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [ ] N/A

**Aditional comments:**


```js
const fs = require('fs');
const path = require('path');
const str = fs.readFileSync(path.join(__dirname, '/hello.txt'), 'utf8');
console.log(str);

function evaluated (blah) {
  const result = fs.readFileSync(path.join(__dirname, blah), 'utf8');
  console.log(result);
}

setTimeout(() => evaluated('/hello.txt'), 1500);
const str2 = fs.readFileSync(path.join(__dirname, '/hello.txt'), 'utf8');
console.log(str2);
```

to be

```js
const fs = require('fs');

const path = require('path');

const str = "hello";
console.log(str);

function evaluated(blah) {
  const result = fs.readFileSync(path.join(__dirname, blah), 'utf8');
  console.log(result);
}

setTimeout(() => evaluated('/hello.txt'), 1500);
const str2 = "hello";
console.log(str2);
```