### PR TITLE
Add support for node: protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function (babel) {
         // We found "require(fs)"
         const staticModuleName = staticModuleNames.find(
           staticModuleName => t.isStringLiteral(arg, { value: staticModuleName })
-        )
+        );
         if (staticModuleName) {
           var id = path.parentPath.node.id;
           var vars = [];

--- a/test/fixtures/cjs5.actual.js
+++ b/test/fixtures/cjs5.actual.js
@@ -1,0 +1,3 @@
+const { readFileSync } = require('node:fs');
+const str = readFileSync(__dirname + '/hello.txt', 'utf8');
+console.log(str);

--- a/test/fixtures/es6-6.actual.js
+++ b/test/fixtures/es6-6.actual.js
@@ -1,0 +1,3 @@
+import { readFileSync } from 'node:fs';
+const str = readFileSync(__dirname + '/hello.txt', 'utf8');
+console.log(str);

--- a/test/index.js
+++ b/test/index.js
@@ -9,12 +9,14 @@ test('babel plugin to accept browserify transforms', function (t) {
   run('cjs2', 'common', 'CommonJS require with destructure');
   run('cjs3', 'common', 'CommonJS require with destructure and local naming');
   run('cjs4', 'common', 'CommonJS require with member expression');
+  run('cjs5', 'common', 'CommonJS require with node: protocol');
 
   run('es6-1', 'common', 'es6 basic import');
   run('es6-2', 'common', 'es6 destructured import');
   run('es6-3', 'common', 'es6 import with "as" statement');
   run('es6-4', 'common', 'es6 import with "as" statement and other declarations');
   run('es6-5', 'common', 'es6 import * as');
+  run('es6-6', 'common', 'es6 node: protocol');
 
   run('path1', 'path1', 'path.join with CommonJS');
   run('path2', 'path2', 'path.join with es6');


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [x] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

Currently, doing `import { readFileSync } from "node:fs"` will not correctly transform.

## Side Effects, Risks, Impact

- [x] N/A